### PR TITLE
Add 'length'  param in bed configuration.

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -25,6 +25,7 @@ class Bed:
     plants_count: int = None
     rows_count: int = 1
     beds_count: int = 1
+    length: float = None
     shift_next_bed: bool = True
     offset: typing.List[float] = field(default_factory=lambda: [0.0, 0.0, 0.0])
     y_function: typing.Callable[float, float] = lambda x: 0.0

--- a/core/parser.py
+++ b/core/parser.py
@@ -58,10 +58,13 @@ def make_bed(name: str, data: dict, default=config.Bed(), allow_none=False):
 
     # if not specified, 'plant_count' is computed from 'length' and 'plant_distance'
     bed.length = data.get('length', default.length)
-    bed.plants_count = data.get('crops_count') or data.get('plants_count', default.plants_count)
+    bed.plants_count = data.get('crops_count') or data.get('plants_count')
     if bed.plants_count is None:
         if bed.length is not None and bed.plant_distance is not None:
             bed.plants_count = int(bed.length / bed.plant_distance)
+        else:
+            bed.plants_count = default.plants_count
+
         if not allow_none and bed.plants_count is None:
             error("unable to dertemine number of plants. Specify 'plant_count' or 'length'.")
 

--- a/doc/configuration_format.md
+++ b/doc/configuration_format.md
@@ -117,6 +117,7 @@ my_bed1:
   plants_count: 100
   beds_count: 10
   plant_distance: .15
+  length: 15.
   shift_next_bed: false
   offset: [0., .3, 0.]
   y_function: '1.4 * sin(x * tau / 15.)'
@@ -135,7 +136,9 @@ The key corresponds to the name of the bed.
   The next bed will be generated with an offset corresponding to the `bed_width` multiplied by
   `bed_count` but only if `shift_next_bed` is disabled.
 * `row_distance` (in meters): distance between two consecutive rows in the bed.
-* `plants_count`: number of plants in a row.
+* `plants_count`: number of plants in a row. `crops_count` is also accepted.
+* `length`: (in meters) length of the bed.
+  It is used to compute the number of plants (only if `plants_count` is not specified)
 * `rows_count` (default: 1): number of rows in a bed.
 * `beds_count` (default: 1): number of bed (the same configuration is repeated).
 * `shift_next_bed` (default: true): a boolean to enable/disable the shift of the next bed.


### PR DESCRIPTION
Instead of specifying `plants_count`, you can use `length` to define the length of the bed and automatically compute `plants_count` using `plant_distance`.