### PR TITLE
Refactor weed collection logic to support multiple blocks of same type

### DIFF
--- a/core/ground.py
+++ b/core/ground.py
@@ -53,15 +53,19 @@ class Ground:
         scene_layer_coll = view_layer.layer_collection
         weeds_layer_coll = scene_layer_coll.children['resources'].children['weeds']
 
-        selected_weed_types_height = [(w.plant_type, w.max_height) for w in self.field.weeds]
+        selected_weed_types_height = [(w.plant_type, w.name, w.max_height) for w in self.field.weeds]
 
-        for weed_type, weed_height in selected_weed_types_height:
+        for weed_type, weed_name, weed_height in selected_weed_types_height:
             # get models from 0 to max_height
             plant_group = plant_manager.get_model_list_by_height(weed_type, weed_height / 2.0, 1)
+            if not plant_group:
+                raise RuntimeError(
+                    f"Error: plant type '{weed_type}' with hight under {weed_height} is unknown.")
 
-            collection = bpy.data.collections.new(weed_type)
+
+            collection = bpy.data.collections.new(weed_name)
             weeds_collection.children.link(collection)
-            group_layer_coll = weeds_layer_coll.children[weed_type]
+            group_layer_coll = weeds_layer_coll.children[weed_name]
 
             for model in plant_group:
                 view_layer.active_layer_collection = group_layer_coll
@@ -118,7 +122,7 @@ class Ground:
     def create_weed(self, weed: config.Weed):
         object = create_plane_object(weed.name, self.beds.width, self.beds.length,
                                      self.field.scattering_extra_width)
-        weed_collection = bpy.data.collections[weed.plant_type]
+        weed_collection = bpy.data.collections[weed.name]
 
         object.modifiers.new('grid', 'REMESH')
 


### PR DESCRIPTION
### Problem

Previously, weed models were grouped into collections based solely on the weed type. This caused issues when trying to generate multiple blocks of the same weed type with different attributes (e.g. max_height, density). Since Blender reused the same collection for all blocks of the same type, duplicate models were created within the same collection, and it was impossible to customize them independently.




### Solution

Now, the collection name is based on the weed_name, which is unique per block. This change ensures that each block of weed regardless of type is processed separately in its own collection. This allows for different settings (like height and density) to be applied independently, even when the weed type is the same.


### Screenshots
**Before:**

Multiple blocks of the same weed type resulted in duplicates in a single collection.
<img width="1005" height="748" alt="Screenshot from 2025-07-23 09-34-47" src="https://github.com/user-attachments/assets/95566961-3675-45b2-8e86-71911882ca9c" />
**After:**

Each block now has its own collection based on weed_name.
  
<img width="1005" height="748" alt="Screenshot from 2025-07-23 09-44-09" src="https://github.com/user-attachments/assets/05a012a7-2200-40d7-bc3c-da3138174b7c" />

